### PR TITLE
refactor(api): added a new DTO layer

### DIFF
--- a/packages/api/src/attendance-record.ts
+++ b/packages/api/src/attendance-record.ts
@@ -1,4 +1,5 @@
 import { zValidator } from "@hono/zod-validator";
+import type { Prisma } from "@sandglass/schema/generated/prisma/client";
 import { db } from "./db";
 import { factory } from "./factory";
 import { HTTPException } from "hono/http-exception";
@@ -29,14 +30,14 @@ export const attendanceRecordRoutes = factory
     zValidator("json", attendanceRecordCreateBodySchema),
     async (c) => {
       const uid = c.var.user.id;
-      const data = c.req.valid("json");
+      const body = c.req.valid("json");
 
       // Validate ProjectId
-      if (data.projectId) {
+      if (body.projectId) {
         const associatedProject = await db.project.findFirst({
           where: {
             uid: uid,
-            id: data.projectId,
+            id: body.projectId,
           },
           select: { id: true },
         });
@@ -46,8 +47,13 @@ export const attendanceRecordRoutes = factory
         }
       }
 
+      const data = {
+        ...body,
+        uid,
+      } satisfies Prisma.AttendanceRecordUncheckedCreateInput;
+
       const createdRecord = await db.attendanceRecord.create({
-        data: { ...data, uid: uid },
+        data,
       });
 
       return c.json(createdRecord);

--- a/packages/api/src/attendance-record.ts
+++ b/packages/api/src/attendance-record.ts
@@ -1,8 +1,12 @@
 import { zValidator } from "@hono/zod-validator";
-import { db, schema } from "./db";
+import { db } from "./db";
 import { factory } from "./factory";
-import { z } from "zod";
 import { HTTPException } from "hono/http-exception";
+import {
+  attendanceRecordCreateBodySchema,
+  attendanceRecordIdBodySchema,
+  attendanceRecordQuerySchema,
+} from "./schemas/attendance";
 
 /**
  * Get day boundaries (00:00:00) for the given date
@@ -22,13 +26,7 @@ export const attendanceRecordRoutes = factory
    */
   .post(
     "/",
-    zValidator(
-      "json",
-      schema.AttendanceRecordUncheckedCreateInputObjectZodSchema.omit({
-        id: true,
-        uid: true,
-      }),
-    ),
+    zValidator("json", attendanceRecordCreateBodySchema),
     async (c) => {
       const uid = c.var.user.id;
       const data = c.req.valid("json");
@@ -55,7 +53,7 @@ export const attendanceRecordRoutes = factory
       return c.json(createdRecord);
     },
   )
-  .delete("/", zValidator("json", z.object({ id: z.uuid() })), async (c) => {
+  .delete("/", zValidator("json", attendanceRecordIdBodySchema), async (c) => {
     const uid = c.var.user.id;
     const idObject = c.req.valid("json");
 
@@ -67,36 +65,7 @@ export const attendanceRecordRoutes = factory
   })
   .get(
     "/",
-    zValidator(
-      "query",
-      z.discriminatedUnion("preset", [
-        z
-          .object({
-            from: z.coerce.date().optional(),
-            to: z.coerce.date().optional(),
-            projectId: z.uuid().optional(),
-            // args that should not be valid
-            preset: z.undefined().optional(),
-          })
-          .refine((data) => {
-            // 'from' and 'to' is valid when
-            // 1. both exists and from < to
-            // 2. both undefined
-            if (data.from && data.to) {
-              return data.from < data.to;
-            } else {
-              return !data.from && !data.to;
-            }
-          }),
-        z.object({
-          projectId: z.uuid().optional(),
-          preset: z.enum(["today", "withIn7days", "withIn30days", "latest"]),
-          // args that should not be valid
-          from: z.undefined().optional(),
-          to: z.undefined().optional(),
-        }),
-      ]),
-    ),
+    zValidator("query", attendanceRecordQuerySchema),
     async (c) => {
       const uid = c.var.user.id;
       const data = c.req.valid("query");

--- a/packages/api/src/attendance-record.ts
+++ b/packages/api/src/attendance-record.ts
@@ -125,6 +125,7 @@ export const attendanceRecordRoutes = factory
             lt: to,
           },
           uid: uid,
+          projectId: data.projectId,
         },
         orderBy: { time: "asc" },
       });

--- a/packages/api/src/attendance-target.ts
+++ b/packages/api/src/attendance-target.ts
@@ -1,4 +1,5 @@
 import { zValidator } from "@hono/zod-validator";
+import type { Prisma } from "@sandglass/schema/generated/prisma/client";
 import { factory } from "./factory";
 import { db } from "./db";
 import {
@@ -14,15 +15,19 @@ export const attendanceTargetRoutes = factory
     zValidator("json", attendanceTargetUpdateBodySchema),
     async (c) => {
       const uid = c.var.user.id;
-      const data = c.req.valid("json");
+      const body = c.req.valid("json");
+      const update = {
+        timeMs: body.timeMs,
+      } satisfies Prisma.AttendanceTargetUncheckedUpdateInput;
+      const create = {
+        uid,
+        timeMs: body.timeMs,
+      } satisfies Prisma.AttendanceTargetUncheckedCreateInput;
 
       const res = await db.attendanceTarget.upsert({
         where: { uid: uid },
-        update: { timeMs: data.timeMs },
-        create: {
-          uid: uid,
-          timeMs: data.timeMs,
-        },
+        update,
+        create,
       });
       return c.json(res);
     },
@@ -39,17 +44,19 @@ export const attendanceTargetRoutes = factory
     zValidator("json", leaveRecordCreateBodySchema),
     async (c) => {
       const uid = c.var.user.id;
-      const data = c.req.valid("json");
+      const body = c.req.valid("json");
+      const create = {
+        uid,
+        ...body,
+      } satisfies Prisma.AttendanceLeaveRecordUncheckedCreateInput;
+      const update = {
+        ...body,
+      } satisfies Prisma.AttendanceLeaveRecordUncheckedUpdateInput;
 
       const res = await db.attendanceLeaveRecord.upsert({
-        where: { uid_date: { date: data.date, uid: uid } },
-        create: {
-          uid: uid,
-          ...data,
-        },
-        update: {
-          ...data,
-        },
+        where: { uid_date: { date: body.date, uid: uid } },
+        create,
+        update,
       });
 
       return c.json(res);

--- a/packages/api/src/attendance-target.ts
+++ b/packages/api/src/attendance-target.ts
@@ -1,20 +1,17 @@
 import { zValidator } from "@hono/zod-validator";
 import { factory } from "./factory";
-import {
-  AttendanceLeaveRecordCreateInputObjectZodSchema,
-  AttendanceTargetCreateInputObjectZodSchema,
-} from "@sandglass/schema/generated/schemas";
 import { db } from "./db";
-import { z } from "zod";
+import {
+  attendanceRecordIdBodySchema,
+  attendanceTargetUpdateBodySchema,
+  leaveRecordCreateBodySchema,
+} from "./schemas/attendance";
 
 export const attendanceTargetRoutes = factory
   .createApp()
   .put(
     "/",
-    zValidator(
-      "json",
-      AttendanceTargetCreateInputObjectZodSchema.omit({ user: true }),
-    ),
+    zValidator("json", attendanceTargetUpdateBodySchema),
     async (c) => {
       const uid = c.var.user.id;
       const data = c.req.valid("json");
@@ -39,13 +36,7 @@ export const attendanceTargetRoutes = factory
   })
   .put(
     "leave",
-    zValidator(
-      "json",
-      AttendanceLeaveRecordCreateInputObjectZodSchema.omit({
-        id: true,
-        user: true,
-      }),
-    ),
+    zValidator("json", leaveRecordCreateBodySchema),
     async (c) => {
       const uid = c.var.user.id;
       const data = c.req.valid("json");
@@ -66,7 +57,7 @@ export const attendanceTargetRoutes = factory
   )
   .delete(
     "leave",
-    zValidator("json", z.object({ id: z.uuid() })),
+    zValidator("json", attendanceRecordIdBodySchema),
     async (c) => {
       const uid = c.var.user.id;
       const data = c.req.valid("json");

--- a/packages/api/src/db.ts
+++ b/packages/api/src/db.ts
@@ -40,7 +40,6 @@ const createPrismaClient = () => {
 };
 
 export const db = createPrismaClient();
-export * as schema from "@sandglass/schema/generated/schemas/index";
 
 async function bootstrap() {
   try {

--- a/packages/api/src/project.ts
+++ b/packages/api/src/project.ts
@@ -1,12 +1,14 @@
 import { zValidator } from "@hono/zod-validator";
 import { db } from "./db";
 import { factory } from "./factory";
-import z from "zod";
-import {
-  ProjectCreateInputObjectZodSchema,
-  ResourcesCreateInputObjectZodSchema,
-} from "@sandglass/schema/generated/schemas";
 import { HTTPException } from "hono/http-exception";
+import {
+  projectCreateBodySchema,
+  projectIdQuerySchema,
+  resourceCreateBodySchema,
+  resourceIdQuerySchema,
+  resourceProjectIdQuerySchema,
+} from "./schemas/project";
 
 export const projectRoutes = factory
   .createApp()
@@ -15,7 +17,7 @@ export const projectRoutes = factory
     const res = await db.project.findMany({ where: { uid: uid } });
     return c.json(res);
   })
-  .get("/", zValidator("query", z.object({ id: z.uuid() })), async (c) => {
+  .get("/", zValidator("query", projectIdQuerySchema), async (c) => {
     const uid = c.var.user.id;
     const data = c.req.valid("query");
 
@@ -24,7 +26,7 @@ export const projectRoutes = factory
     });
     return c.json(res);
   })
-  .delete("/", zValidator("query", z.object({ id: z.uuid() })), async (c) => {
+  .delete("/", zValidator("query", projectIdQuerySchema), async (c) => {
     const uid = c.var.user.id;
     const data = c.req.valid("query");
 
@@ -33,15 +35,7 @@ export const projectRoutes = factory
   })
   .post(
     "/",
-    zValidator(
-      "json",
-      ProjectCreateInputObjectZodSchema.omit({
-        id: true,
-        user: true,
-        resources: true,
-        attendanceRecords: true,
-      }),
-    ),
+    zValidator("json", projectCreateBodySchema),
     async (c) => {
       const uid = c.var.user.id;
       const data = c.req.valid("json");
@@ -55,7 +49,7 @@ export const ResourcesRoutes = factory
   .createApp()
   .get(
     "/",
-    zValidator("query", z.object({ projectId: z.uuid() })),
+    zValidator("query", resourceProjectIdQuerySchema),
     async (c) => {
       const uid = c.var.user.id;
       const projectId = c.req.valid("query").projectId;
@@ -74,11 +68,8 @@ export const ResourcesRoutes = factory
   )
   .post(
     "/",
-    zValidator("query", z.object({ projectId: z.uuid() })),
-    zValidator(
-      "json",
-      ResourcesCreateInputObjectZodSchema.omit({ id: true, project: true }),
-    ),
+    zValidator("query", resourceProjectIdQuerySchema),
+    zValidator("json", resourceCreateBodySchema),
     async (c) => {
       const uid = c.var.user.id;
       const projectId = c.req.valid("query").projectId;
@@ -106,7 +97,7 @@ export const ResourcesRoutes = factory
   )
   .delete(
     "/",
-    zValidator("query", z.object({ resourceId: z.uuid() })),
+    zValidator("query", resourceIdQuerySchema),
     async (c) => {
       const uid = c.var.user.id;
       const resourceId = c.req.valid("query").resourceId;

--- a/packages/api/src/project.ts
+++ b/packages/api/src/project.ts
@@ -1,4 +1,5 @@
 import { zValidator } from "@hono/zod-validator";
+import type { Prisma } from "@sandglass/schema/generated/prisma/client";
 import { db } from "./db";
 import { factory } from "./factory";
 import { HTTPException } from "hono/http-exception";
@@ -38,9 +39,13 @@ export const projectRoutes = factory
     zValidator("json", projectCreateBodySchema),
     async (c) => {
       const uid = c.var.user.id;
-      const data = c.req.valid("json");
+      const body = c.req.valid("json");
+      const data = {
+        ...body,
+        uid,
+      } satisfies Prisma.ProjectUncheckedCreateInput;
 
-      const res = await db.project.create({ data: { ...data, uid: uid } });
+      const res = await db.project.create({ data });
       return c.json(res);
     },
   );
@@ -81,15 +86,17 @@ export const ResourcesRoutes = factory
       }
 
       const resource = c.req.valid("json");
-      const createdResource = await db.resources.create({
-        data: {
-          ...resource,
-          project: {
-            connect: {
-              id: projectId,
-            },
+      const data = {
+        ...resource,
+        project: {
+          connect: {
+            id: projectId,
           },
         },
+      } satisfies Prisma.ResourcesCreateInput;
+
+      const createdResource = await db.resources.create({
+        data,
       });
 
       return c.json(createdResource);

--- a/packages/api/src/schemas/attendance.ts
+++ b/packages/api/src/schemas/attendance.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+
+const attendanceTypeSchema = z.enum(["IN", "OUT", "PAUSE"]);
+
+// These schemas describe the HTTP boundary, not the full Prisma write models.
+// That keeps auth-owned fields like uid and relation fields out of route inputs.
+export const attendanceTargetUpdateBodySchema = z.object({
+  timeMs: z.int(),
+});
+
+export const leaveRecordCreateBodySchema = z.object({
+  date: z.coerce.date(),
+  timeMs: z.int(),
+  summary: z.string().optional().nullable(),
+});
+
+export const attendanceRecordIdBodySchema = z.object({
+  id: z.uuid(),
+});
+
+export const attendanceRecordCreateBodySchema = z.object({
+  time: z.coerce.date(),
+  summary: z.string().optional().nullable(),
+  type: attendanceTypeSchema,
+  projectId: z.uuid().optional().nullable(),
+});
+
+export const attendanceRecordQuerySchema = z.discriminatedUnion("preset", [
+  z
+    .object({
+      from: z.coerce.date().optional(),
+      to: z.coerce.date().optional(),
+      projectId: z.uuid().optional(),
+      preset: z.undefined().optional(),
+    })
+    .refine((data) => {
+      if (data.from && data.to) {
+        return data.from < data.to;
+      }
+
+      return !data.from && !data.to;
+    }),
+  z.object({
+    projectId: z.uuid().optional(),
+    preset: z.enum(["today", "withIn7days", "withIn30days", "latest"]),
+    from: z.undefined().optional(),
+    to: z.undefined().optional(),
+  }),
+]);
+
+export type AttendanceRecordType = z.infer<typeof attendanceTypeSchema>;

--- a/packages/api/src/schemas/project.ts
+++ b/packages/api/src/schemas/project.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+// HTTP input schemas stay local to the API layer so route contracts can evolve
+// without inheriting Prisma create-input details and relation fields.
+export const projectIdQuerySchema = z.object({
+  id: z.uuid(),
+});
+
+export const projectCreateBodySchema = z.object({
+  name: z.string(),
+  calendarId: z.string(),
+  tasklistId: z.string(),
+  repoOwner: z.string(),
+  repoName: z.string(),
+});
+
+export const resourceProjectIdQuerySchema = z.object({
+  projectId: z.uuid(),
+});
+
+export const resourceCreateBodySchema = z.object({
+  title: z.string(),
+  url: z.string(),
+});
+
+export const resourceIdQuerySchema = z.object({
+  resourceId: z.uuid(),
+});

--- a/packages/web/src/views/attendance/hooks.ts
+++ b/packages/web/src/views/attendance/hooks.ts
@@ -1,8 +1,10 @@
-import type { AttendanceRecord } from '@/services-composable/attendance-record'
-import type { AttendanceType } from '../../../../schema/generated/schemas'
+import type {
+  AttendanceRecord,
+  AttendanceRecordType,
+} from '@/services-composable/attendance-record'
 
 export function computeWorkTimeOfToday(records: AttendanceRecord[]) {
-  let statusMachine: AttendanceType = 'OUT'
+  let statusMachine: AttendanceRecordType = 'OUT'
   let statusMachineCachedTime: Date = new Date()
   let statusMachineCountTimeMs = 0
   for (const r of records) {


### PR DESCRIPTION
This pull request refactors the API layer for attendance and project management to use local, purpose-built Zod schemas for input validation instead of directly using Prisma-generated schemas. This improves the separation between HTTP API contracts and database models, making the codebase easier to maintain and evolve. The changes also standardize how user-owned fields are handled and simplify route handler logic.

**API Input Validation Refactor:**

* Introduced new local Zod schemas in `packages/api/src/schemas/attendance.ts` and `packages/api/src/schemas/project.ts` for validating request bodies and query parameters, replacing direct usage of Prisma-generated schemas. These schemas are now used throughout the attendance and project routes for cleaner, more maintainable input validation. [[1]](diffhunk://#diff-4a0f577371f2b9ffe392bad6f2993a9228cc22ef916751db463b283a7ec3ca91R1-R51) [[2]](diffhunk://#diff-a44259a21a059e9aafb7d0f63e6c43993a4dc0e02e6fc5bf67276b00253dc866R1-R28)
* Updated all route handlers in `attendance-record.ts`, `attendance-target.ts`, and `project.ts` to use the new schemas with `zValidator`, removing imports and usage of Prisma schema objects. [[1]](diffhunk://#diff-18e0484521428d6801589483b9be0a28c04db7a539e54e273ee968e49eab53f2L2-R10) [[2]](diffhunk://#diff-18e0484521428d6801589483b9be0a28c04db7a539e54e273ee968e49eab53f2L25-R40) [[3]](diffhunk://#diff-18e0484521428d6801589483b9be0a28c04db7a539e54e273ee968e49eab53f2L70-R74) [[4]](diffhunk://#diff-18e0484521428d6801589483b9be0a28c04db7a539e54e273ee968e49eab53f2R50-R62) [[5]](diffhunk://#diff-18e0484521428d6801589483b9be0a28c04db7a539e54e273ee968e49eab53f2R128) [[6]](diffhunk://#diff-52d717ea700958ea41b485a45cf9f8d19b4ae07834e0b4f2f3d52590b703beebR2-R30) [[7]](diffhunk://#diff-52d717ea700958ea41b485a45cf9f8d19b4ae07834e0b4f2f3d52590b703beebL42-R67) [[8]](diffhunk://#diff-a088dd2198dbd1b86d0a5e978bcbaf4a8bfea14b8226a1e716f58f8df861d7ccR2-R12) [[9]](diffhunk://#diff-a088dd2198dbd1b86d0a5e978bcbaf4a8bfea14b8226a1e716f58f8df861d7ccL18-R21) [[10]](diffhunk://#diff-a088dd2198dbd1b86d0a5e978bcbaf4a8bfea14b8226a1e716f58f8df861d7ccL27-R30) [[11]](diffhunk://#diff-a088dd2198dbd1b86d0a5e978bcbaf4a8bfea14b8226a1e716f58f8df861d7ccL36-R48) [[12]](diffhunk://#diff-a088dd2198dbd1b86d0a5e978bcbaf4a8bfea14b8226a1e716f58f8df861d7ccL58-R57) [[13]](diffhunk://#diff-a088dd2198dbd1b86d0a5e978bcbaf4a8bfea14b8226a1e716f58f8df861d7ccL77-R77) [[14]](diffhunk://#diff-a088dd2198dbd1b86d0a5e978bcbaf4a8bfea14b8226a1e716f58f8df861d7ccL93-R107)

**Code Simplification and Consistency:**

* Route handlers now construct database input objects using the validated request data and explicitly add user-owned fields (e.g., `uid`) as needed, ensuring a clear separation between API and database layers. [[1]](diffhunk://#diff-18e0484521428d6801589483b9be0a28c04db7a539e54e273ee968e49eab53f2R50-R62) [[2]](diffhunk://#diff-52d717ea700958ea41b485a45cf9f8d19b4ae07834e0b4f2f3d52590b703beebR2-R30) [[3]](diffhunk://#diff-52d717ea700958ea41b485a45cf9f8d19b4ae07834e0b4f2f3d52590b703beebL42-R67) [[4]](diffhunk://#diff-a088dd2198dbd1b86d0a5e978bcbaf4a8bfea14b8226a1e716f58f8df861d7ccL36-R48) [[5]](diffhunk://#diff-a088dd2198dbd1b86d0a5e978bcbaf4a8bfea14b8226a1e716f58f8df861d7ccL77-R77) [[6]](diffhunk://#diff-a088dd2198dbd1b86d0a5e978bcbaf4a8bfea14b8226a1e716f58f8df861d7ccL93-R107)
* Removed unused imports and re-exports of Prisma schema objects from the API layer, further decoupling the HTTP and database models.

**Type Consistency:**

* Updated type imports and usage in the web frontend (`hooks.ts`) to reflect the new `AttendanceRecordType` definition, ensuring type safety and consistency across the codebase.