### PR TITLE
chores: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: bun
+    directory: /packages/api
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: bun
+    directory: /packages/web
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This pull request adds a `.github/dependabot.yml` configuration file to enable automated dependency updates for the project. Dependabot will now check for new versions of dependencies in the main project directory as well as the `api` and `web` packages on a weekly schedule.

Dependency management automation:

* Added `.github/dependabot.yml` to configure Dependabot for the `bun` package ecosystem in the root, `/packages/api`, and `/packages/web` directories, with updates scheduled weekly.